### PR TITLE
Allow setting the country programmatically by alpha2, alpha3, and name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,11 @@ import { CountrySelectComponent } from '@wlucha/ng-country-select';
 | Parameter            | Type                      | Default            | Description                                                                |
 |----------------------|---------------------------|--------------------|----------------------------------------------------------------------------|
 | `defaultCountry`     | `Country \| null`         | `null`             | Sets an initial preselected country                                        |
-| `formControl`        | `FormControl<Country \| null`>         | `null`                  | Sets an initial preselected country (FormControl)             |
+| `formControl`        | `FormControl<Country \| null`>         | `null`                  | Sets an initial preselected country (FormControl)        |
 | `selectedCountry`    | `Country \| null`         | -                  | Sets a country programmatically (after init)                               |
+| `selectedCountryByAlpha2` | `string`             | -                  | Set a country programmatically by its alpha2 code                          |
+| `selectedCountryByAlpha3` | `string`             | -                  | Set a country programmatically by its alpha3 code                          |
+| `selectedCountryByCurrentTranslation` |          | -                  | Set a country programmatically by its name in the current language         |
 | `lang`               | `string`                  | `'en'`             | Language for displaying country names (e.g., `en`, `de`, `fr`, `es`, `it`) |
 | `searchAllLanguages` | `boolean`                 | `false`            | If `true`, searching will match in **all** available translations          |
 | `placeholder`        | `string`                  | `'Search country'` | Placeholder text for the input field                                       |

--- a/projects/wlucha/ng-country-select/src/lib/country-select.component.ts
+++ b/projects/wlucha/ng-country-select/src/lib/country-select.component.ts
@@ -83,6 +83,39 @@ export class CountrySelectComponent implements OnInit {
   }
 
   /**
+   * Set a country programmatically by its alpha2 code
+   */
+  @Input() public set selectedCountryByAlpha2(alpha2: string) {
+    const country: Country | undefined = countries.find(c => c.alpha2 === alpha2);
+
+    if (country) {
+      this.formControl.setValue(country);
+    }
+  }
+
+  /**
+   * Set a country programmatically by its alpha3 code
+   */
+  @Input() public set selectedCountryByAlpha3(alpha3: string) {
+    const country: Country | undefined = countries.find(c => c.alpha3 === alpha3);
+
+    if (country) {
+      this.formControl.setValue(country);
+    }
+  }
+
+  /**
+   * Set a country programmatically by its name in the current language
+   */
+  @Input() public set selectedCountryByCurrentTranslation(name: string) {
+    const country: Country | undefined = countries.find((c: Country) => c.translations[this.lang] === name);
+
+    if (country) {
+      this.formControl.setValue(country);
+    }
+  }
+
+  /**
    * Form control for the country select
    */
   @Input() public formControl = new FormControl<Country | null>(null);

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -89,7 +89,7 @@ ng add &#64;wlucha/ng-country-select
   <!-- Example 6: Set language & placeholder -->
   <div class="example">
     <h2>6. Set language & placeholder</h2>
-    
+
     <mat-tab-group>
       <mat-tab label="HTML">
         <div class="code">
@@ -102,7 +102,7 @@ ng add &#64;wlucha/ng-country-select
           </code></pre>
         </div>
       </mat-tab>
-  
+
       <mat-tab label="TypeScript">
         <div class="code">
           <pre><code class="language-typescript">
@@ -135,16 +135,14 @@ ng add &#64;wlucha/ng-country-select
         </div>
       </mat-tab>
     </mat-tab-group>
-  
+
     <div class="preview two-column-layout">
       <div class="left-column">
-        <ng-country-select 
-          [lang]="selectedLang" 
-          [placeholder]="placeholderMap[selectedLang]"
+        <ng-country-select [lang]="selectedLang" [placeholder]="placeholderMap[selectedLang]"
           [defaultCountry]="presetCountry">
         </ng-country-select>
       </div>
-  
+
       <div class="right-column">
         <mat-radio-group [(ngModel)]="selectedLang" class="radio-group">
           <div class="radio-column">
@@ -154,7 +152,7 @@ ng add &#64;wlucha/ng-country-select
             <mat-radio-button [value]="'es'">Español</mat-radio-button>
             <mat-radio-button [value]="'zh'">中文</mat-radio-button>
           </div>
-          
+
           <div class="radio-column">
             <mat-radio-button [value]="'ar'">العربية</mat-radio-button>
             <mat-radio-button [value]="'hi'">हिंदी</mat-radio-button>
@@ -212,9 +210,42 @@ ng add &#64;wlucha/ng-country-select
     </div>
   </div>
 
-  <!-- Example 10: All Inputs and Outputs -->
+  <!-- Example 10: Set a country programmatically by Alpha2 -->
   <div class="example">
-    <h2>10. All Inputs & Outputs</h2>
+    <h2>10. Set a country programmatically by Alpha2</h2>
+    <div class="code">
+      <pre><code class="language-html">
+  &lt;ng-country-select
+    [selectedCountryByAlpha2]="alpha2Country"
+  &gt;&lt;/ng-country-select&gt;
+                  </code></pre>
+    </div>
+    <div class="preview">
+      <ng-country-select [selectedCountryByAlpha2]="alpha2Country"></ng-country-select>
+      <div> <button mat-raised-button (click)="setCountryByAlpha2()">Set Germany as country</button></div>
+    </div>
+  </div>
+
+    <!-- Example 11: Set a country programmatically by Alpha3 -->
+    <div class="example">
+      <h2>11. Set a country programmatically by Alpha3</h2>
+      <div class="code">
+        <pre><code class="language-html">
+    &lt;ng-country-select
+      [selectedCountryByAlpha3]="alpha3Country"
+    &gt;&lt;/ng-country-select&gt;
+                    </code></pre>
+      </div>
+      <div class="preview">
+        <ng-country-select [selectedCountryByAlpha3]="alpha3Country"></ng-country-select>
+        <div> <button mat-raised-button (click)="setCountryByAlpha3()">Set Germany as country</button></div>
+      </div>
+    </div>
+
+
+  <!-- Example 12: All Inputs and Outputs -->
+  <div class="example">
+    <h2>12. All Inputs & Outputs</h2>
     <div class="code">
       <pre><code class="language-html">
 &lt;ng-country-select
@@ -248,35 +279,4 @@ ng add &#64;wlucha/ng-country-select
     </div>
   </div>
 
-  <!-- Example 11: Set country by Alpha2 -->
-  <div class="example">
-    <h2>11. Set country programmatically</h2>
-    <div class="code">
-      <pre><code class="language-html">
-&lt;ng-country-select #countrySelect
-&gt;&lt;/ng-country-select&gt;
-      </code></pre>
-      <pre><code class="language-typescript">
-        import &#123; Component, OnInit, viewChild &#125; from '&#64;angular/core';
-        import &#123; CountrySelectComponent, Country &#125; from '&#64;wlucha/ng-country-select';
-                  
-        &#64;Component&#123; 
-            selector: 'app-country-select', 
-            templateUrl: './country-select.component.html', 
-            styleUrls: ['./country-select.component.css'],
-            imports: [CountrySelectComponent]
-          &#125;
-          export class CountrySelectExampleComponent implements OnInit &#123;
-            countrySelect = viewChild&#60;CountrySelectComponent&#62;;
-
-            ngOnInit(): &#123;
-              this.countrySelect.selectedCountryByAlpha2 = 'de';
-            &#125;    
-        &#125;
-                  </code></pre>
-    </div>
-    <div class="preview">
-      <ng-country-select #countrySelect ></ng-country-select>
-    </div>
-  </div>
 </div>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -115,7 +115,7 @@ ng add &#64;wlucha/ng-country-select
       styleUrls: ['./country-select.component.css'],
       imports: [CountrySelectComponent]
     &#125;
-    export class CountrySelectComponent &#123;
+    export class CountrySelectExampleComponent &#123;
       selectedLang: string = 'en';
       placeholderMap = &#123;
         'en': 'Select Country',
@@ -245,6 +245,38 @@ ng add &#64;wlucha/ng-country-select
       <div>
         Selected: {{ countryControl.value | json }}
       </div>
+    </div>
+  </div>
+
+  <!-- Example 11: Set country by Alpha2 -->
+  <div class="example">
+    <h2>11. Set country programmatically</h2>
+    <div class="code">
+      <pre><code class="language-html">
+&lt;ng-country-select #countrySelect
+&gt;&lt;/ng-country-select&gt;
+      </code></pre>
+      <pre><code class="language-typescript">
+        import &#123; Component, OnInit, viewChild &#125; from '&#64;angular/core';
+        import &#123; CountrySelectComponent, Country &#125; from '&#64;wlucha/ng-country-select';
+                  
+        &#64;Component&#123; 
+            selector: 'app-country-select', 
+            templateUrl: './country-select.component.html', 
+            styleUrls: ['./country-select.component.css'],
+            imports: [CountrySelectComponent]
+          &#125;
+          export class CountrySelectExampleComponent implements OnInit &#123;
+            countrySelect = viewChild&#60;CountrySelectComponent&#62;;
+
+            ngOnInit(): &#123;
+              this.countrySelect.selectedCountryByAlpha2 = 'de';
+            &#125;    
+        &#125;
+                  </code></pre>
+    </div>
+    <div class="preview">
+      <ng-country-select #countrySelect ></ng-country-select>
     </div>
   </div>
 </div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,5 +1,5 @@
 import { JsonPipe } from '@angular/common';
-import { Component } from '@angular/core';
+import { Component, OnInit, viewChild } from '@angular/core';
 import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { CountrySelectComponent, Country } from '@wlucha/ng-country-select';
 import hljs from 'highlight.js';
@@ -14,7 +14,7 @@ import { MatTabsModule } from '@angular/material/tabs';
   templateUrl: './app.component.html',
   styleUrl: './app.component.scss'
 })
-export class AppComponent {
+export class AppComponent implements OnInit {
 
   presetCountry: Country = {
     alpha2: 'de',
@@ -52,6 +52,12 @@ export class AppComponent {
   selectedCountry?: Country;
 
   selectedLang: string = 'en';
+
+  countrySelect = viewChild<CountrySelectComponent>;
+
+  ngOnInit(): void {
+    this.countrySelect.selectedCountryByAlpha2 = 'de';
+  }
 
   // Lifecycle hook to highlight code blocks after view initialization
   ngAfterViewInit(): void {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,20 +1,23 @@
 import { JsonPipe } from '@angular/common';
-import { Component, OnInit, viewChild } from '@angular/core';
+import { Component } from '@angular/core';
 import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { CountrySelectComponent, Country } from '@wlucha/ng-country-select';
 import hljs from 'highlight.js';
 import { MatRadioModule } from '@angular/material/radio';
 import { MatTabsModule } from '@angular/material/tabs';
+import {MatButtonModule} from '@angular/material/button';
+
+
 
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [FormsModule, ReactiveFormsModule, MatRadioModule, MatTabsModule, JsonPipe, CountrySelectComponent],
+  imports: [FormsModule, ReactiveFormsModule, MatRadioModule, MatTabsModule, MatButtonModule, JsonPipe, CountrySelectComponent],
   templateUrl: './app.component.html',
   styleUrl: './app.component.scss'
 })
-export class AppComponent implements OnInit {
+export class AppComponent {
 
   presetCountry: Country = {
     alpha2: 'de',
@@ -52,12 +55,8 @@ export class AppComponent implements OnInit {
   selectedCountry?: Country;
 
   selectedLang: string = 'en';
-
-  countrySelect = viewChild<CountrySelectComponent>;
-
-  ngOnInit(): void {
-    this.countrySelect.selectedCountryByAlpha2 = 'de';
-  }
+  alpha2Country: string = '';
+  alpha3Country: string = '';
 
   // Lifecycle hook to highlight code blocks after view initialization
   ngAfterViewInit(): void {
@@ -68,6 +67,14 @@ export class AppComponent implements OnInit {
   public onCountrySelected(country: Country): void {
     this.selectedCountry = country;
   }
+
+  public setCountryByAlpha2(): void {
+   this.alpha2Country = 'de';
+  }
+
+  public setCountryByAlpha3(): void {
+    this.alpha3Country = 'deu';
+   }
 
   public onInputChanged(searchTerm: string): void {
     console.log('Search Term:', searchTerm);


### PR DESCRIPTION
This PR adds 3 new setters to provide some flexibility in setting the initial value for a country selector (requested in #17):

* `selectedCountryByAlpha2`
* `selectedCountryByAlpha3`
* `selectedCountryByCurrentTranslation`

I tried adding an example for Alpha2 but I'm not really sure how to properly build and run the package + application.